### PR TITLE
added test and response for get_pokedata connection error

### DIFF
--- a/fastapi_pokedex_api/pokeapi_requests.py
+++ b/fastapi_pokedex_api/pokeapi_requests.py
@@ -18,6 +18,11 @@ def get_pokedata(ip_settings: PokeapiSettings, poke_name: str) -> PokedexBase:
             status_code=404,
             detail="pokemon '{}' not found. Check spelling".format(name),
         )
+    except requests.ConnectionError:
+        raise fastapi.HTTPException(
+            status_code=501,
+            detail="Connection error, check internet connection and retry",
+        )
 
     try:
         details = response.json()

--- a/tests/get_pokedata_test.py
+++ b/tests/get_pokedata_test.py
@@ -36,3 +36,12 @@ def test_get_pokedata_bad_status_code() -> None:
             get_pokedata(
                 ip_settings=PokeapiSettings(POKEAPI_IP=POKEAPI_IP), poke_name="pikachu"
             )
+
+
+def test_get_pokedata_failed_connection() -> None:
+    with requests_mock.Mocker() as m:
+        m.get(f"{POKEAPI_IP}pikachu", exc=requests.exceptions.ConnectionError)
+        with pytest.raises(fastapi.HTTPException):
+            get_pokedata(
+                ip_settings=PokeapiSettings(POKEAPI_IP=POKEAPI_IP), poke_name="pikachu"
+            )


### PR DESCRIPTION
Added an connection error exception to:
`try:
      response = requests.get("pokemon data"`)

within pokeapi_requests.py
to pick up a connection error if one arises and then raising an http 501 error explaining what happened
and an associating test from within get_pokedata_test.py with test_get_pokedata_failed_connection() 